### PR TITLE
[Feature] Add login account proof

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ChakraProvider } from "@chakra-ui/react";
 import { ReactJSXElement } from "@emotion/react/types/jsx-namespace";
 import Header from "./components/Header";
+import LoginModal from "./components/LoginModal";
 import Playground from "./components/Playground";
 import ContextProvider from "./context/Context";
 
@@ -11,6 +12,7 @@ const App = (): ReactJSXElement => {
       <ContextProvider>
         <Header />
         <Playground />
+        <LoginModal />
       </ContextProvider>
     </ChakraProvider>
   );

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,141 @@
+import React, { useContext, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Radio,
+  RadioGroup,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import { Context, LoginMethod } from "../context/Context";
+
+const METHODS = [
+  { title: "Login without account proof 😜", value: LoginMethod.Authn },
+  { title: "Provable login", value: LoginMethod.ProvableAuthn },
+];
+
+const DEFAULT_METHOD_VALUE = METHODS[0].value;
+
+const LoginModal: React.FC = () => {
+  const [method, setMethod] = useState(DEFAULT_METHOD_VALUE);
+  const [appDomainTag, setAppDomainTag] = useState("");
+  const [isTagInvalid, setIsTagInvalid] = useState(false);
+  const { confirmFlowLogin, isLoginModalOpen, closeLoginModal } =
+    useContext(Context);
+
+  const handleChange = (updatedValue: string) => {
+    setMethod(+updatedValue);
+  };
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setIsTagInvalid(
+      Buffer.from(event.target.value).toString("hex").length > 64
+    );
+    setAppDomainTag(event.target.value);
+  };
+
+  const handleLogin = () => {
+    if (confirmFlowLogin) {
+      confirmFlowLogin(method, appDomainTag);
+      handleClose();
+    }
+  };
+
+  const handleClose = () => {
+    setMethod(DEFAULT_METHOD_VALUE);
+    setAppDomainTag("");
+    setIsTagInvalid(false);
+
+    if (closeLoginModal) {
+      closeLoginModal();
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={!!isLoginModalOpen}
+      onClose={handleClose}
+      isCentered
+      closeOnOverlayClick
+    >
+      <ModalOverlay />
+
+      <ModalContent>
+        <ModalHeader>
+          Login Method
+          <ModalCloseButton _focus={{ boxShadow: "none" }} />
+        </ModalHeader>
+
+        <ModalBody>
+          <Text fontSize="large">Please select the way to log in:</Text>
+          <RadioGroup onChange={handleChange} value={method} mt={4}>
+            <Flex flexDirection="column">
+              <Radio value={METHODS[0].value}>
+                <Text fontWeight="semibold">{METHODS[0].title}</Text>
+              </Radio>
+
+              <Flex flexDirection="column" mt={3}>
+                <Radio value={METHODS[1].value}>
+                  <Text fontWeight="semibold">{METHODS[1].title}</Text>
+                </Radio>
+                <Flex mt={2}>
+                  <Box width={4} height={4} />
+                  <Flex flexDirection="column" ml={2}>
+                    <Text fontSize="sm" color="slategrey">
+                      Custom app domain tag (Optional)
+                    </Text>
+                    <Tooltip
+                      label="Please keep the string less than or equal to 32 bytes"
+                      isDisabled={!isTagInvalid}
+                    >
+                      <Input
+                        value={appDomainTag}
+                        onChange={handleInputChange}
+                        disabled={method !== METHODS[1].value}
+                        isInvalid={method === METHODS[1].value && isTagInvalid}
+                        errorBorderColor={
+                          method === METHODS[1].value && isTagInvalid
+                            ? "red.300"
+                            : undefined
+                        }
+                        focusBorderColor={isTagInvalid ? "red.300" : undefined}
+                        placeholder="AWESOME-APP-V0.0-user"
+                        size="sm"
+                        width="300px"
+                        borderRadius="lg"
+                        mt={1}
+                      />
+                    </Tooltip>
+                  </Flex>
+                </Flex>
+              </Flex>
+            </Flex>
+          </RadioGroup>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            disabled={method === METHODS[1].value && isTagInvalid}
+            colorScheme="blue"
+            onClick={handleLogin}
+          >
+            Log in
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default LoginModal;

--- a/src/context/Context.tsx
+++ b/src/context/Context.tsx
@@ -1,21 +1,33 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { useToast } from "@chakra-ui/react";
 import * as fcl from "@blocto/fcl";
 import { ChainServices } from "../services";
 import { Chains, ChainsType } from "../types/ChainTypes";
 import User from "../types/User";
 import { TabInfos } from "../components/Header";
+import { verifyAccountProofSignature } from "../utils/verifyAccountProofSignature";
+
+export enum LoginMethod {
+  Authn,
+  ProvableAuthn,
+}
 
 export const Context: React.Context<{
   chain?: ChainsType;
   switchChain?: (chain: ChainsType) => void;
   address?: string;
   login?: () => Promise<string>;
+  confirmFlowLogin?: (loginMethod: LoginMethod, appDomainTag?: string) => void;
   logout?: () => void;
+  isLoginModalOpen?: boolean;
+  closeLoginModal?: () => void;
 }> = React.createContext({});
 
 const ContextProvider: React.FC = ({ children }) => {
   const [chain, setChain] = useState<ChainsType>(TabInfos[0].chain);
   const [address, setAddress] = useState<string>();
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const toast = useToast();
 
   useEffect(
     () =>
@@ -32,10 +44,23 @@ const ContextProvider: React.FC = ({ children }) => {
     setAddress(newAddress || "");
   }, []);
 
+  const logout = useCallback(async () => {
+    if (chain === Chains.Flow) {
+      if (ChainServices.getChainAddress(Chains.Flow)) {
+        fcl.unauthenticate();
+      }
+      return;
+    }
+
+    localStorage.removeItem("sdk.session");
+
+    setAddress("");
+  }, [chain]);
+
   const login = useCallback(async () => {
     if (chain === Chains.Flow) {
       if (!ChainServices.getChainAddress(Chains.Flow)) {
-        fcl.authenticate();
+        setIsLoginModalOpen(true);
       }
       return;
     }
@@ -54,21 +79,68 @@ const ContextProvider: React.FC = ({ children }) => {
     return accounts[0];
   }, [chain]);
 
-  const logout = useCallback(async () => {
-    if (chain === Chains.Flow) {
-      if (ChainServices.getChainAddress(Chains.Flow)) {
-        fcl.unauthenticate();
+  const confirmFlowLogin = useCallback(
+    async (loginMethod: LoginMethod, appDomainTag = "") => {
+      if (loginMethod === LoginMethod.ProvableAuthn && appDomainTag) {
+        fcl.config().put("fcl.appDomainTag", appDomainTag);
       }
-      return;
-    }
 
-    localStorage.removeItem("sdk.session");
+      if (!ChainServices.getChainAddress(Chains.Flow)) {
+        fcl.authenticate().then((response: any) => {
+          if (loginMethod === LoginMethod.Authn) {
+            return; // Don't verify the signature
+          }
 
-    setAddress("");
-  }, [chain]);
+          const { services = [] } = response || {};
+
+          const accountProofService = services.find(
+            (service: any) => service.type === "account-proof"
+          );
+          if (accountProofService) {
+            const {
+              data: { address, appDomainTag, timestamp, signatures },
+            } = accountProofService;
+
+            verifyAccountProofSignature({
+              address,
+              timestamp,
+              appDomainTag,
+              signatures,
+            }).then((isValid: boolean) => {
+              if (!isValid) {
+                toast({
+                  title:
+                    "Failed to verify the login signature. We will log the current user out.",
+                  status: "error",
+                  duration: 3000,
+                });
+                logout();
+              }
+            });
+          }
+        });
+      }
+    },
+    [logout, toast]
+  );
+
+  const closeLoginModal = useCallback(() => {
+    setIsLoginModalOpen(false);
+  }, []);
 
   return (
-    <Context.Provider value={{ chain, switchChain, address, login, logout }}>
+    <Context.Provider
+      value={{
+        chain,
+        switchChain,
+        address,
+        login,
+        confirmFlowLogin,
+        logout,
+        isLoginModalOpen,
+        closeLoginModal,
+      }}
+    >
       {children}
     </Context.Provider>
   );

--- a/src/utils/verifyAccountProofSignature.ts
+++ b/src/utils/verifyAccountProofSignature.ts
@@ -1,0 +1,29 @@
+import * as fcl from "@blocto/fcl";
+
+interface Params {
+  address: string;
+  timestamp: number;
+  appDomainTag?: string;
+  signatures: Array<{
+    f_type: "CompositeSignature";
+    f_vsn: string;
+    addr: string;
+    signature: string;
+    keyId: number;
+  }>;
+}
+
+export const verifyAccountProofSignature = ({
+  address,
+  timestamp,
+  appDomainTag,
+  signatures,
+}: Params): Promise<boolean> => {
+  const provableMessage =
+    fcl.WalletUtils.encodeMessageForProvableAuthnVerifying(
+      address,
+      timestamp,
+      appDomainTag
+    );
+  return fcl.verifyUserSignatures(provableMessage, signatures);
+};


### PR DESCRIPTION
Allow users to select whether to log in with account proof verification on Flow. When the verification fails, we log the user out. Keep the login process for Ethereum and Solana the same as before.
> **Note**
Will need to update the verify function once we upgrade FCL to the newer version

**Related PR**
The verification will fail until https://github.com/portto/wallet-webapp/pull/70 is merged.

**Screenshot**
<img width="523" alt="截圖 2022-08-25 上午10 19 28" src="https://user-images.githubusercontent.com/32261044/186559342-246fae80-e6db-4998-9a0e-cce27336f16b.png">
When the custom domain tag is too long
<img width="516" alt="截圖 2022-08-25 上午10 20 40" src="https://user-images.githubusercontent.com/32261044/186559372-cc7c3299-02b7-4580-8c49-576eaf5ddea7.png">
